### PR TITLE
auth kwarg should be auth_type

### DIFF
--- a/nb_conda_store_kernels/manager.py
+++ b/nb_conda_store_kernels/manager.py
@@ -58,7 +58,7 @@ class CondaStoreKernelSpecManager(KernelSpecManager):
     async def _kernel_specs(self):
         async with api.CondaStoreAPI(
             conda_store_url=self.conda_store_url,
-            auth=self.conda_store_auth,
+            auth_type=self.conda_store_auth,
             verify_ssl=self.conda_store_verify_ssl,
         ) as conda_store_api:
             environments = await conda_store_api.list_environments(


### PR DESCRIPTION
@costrouc just a small update, looks like the kwarg changed at some point on conda-store

https://github.com/Quansight/conda-store/blob/main/conda-store/conda_store/api.py#L24